### PR TITLE
feat: add week11 feature flags ab testing and canary rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ AI OSS 실습 과제 저장 및 관리 공간
 - **[8주차]** 워크플로우 실행 최적화 (재사용/캐싱/조건부) → [`assignments/L08/README.md`](assignments/L08/README.md)
 - **[9주차]** npm 패키지 배포, Docker 이미지 자동화, Dependabot/보안 스캔 설정 → [`assignments/L09/README.md`](assignments/L09/README.md)
 - **[10주차]** 프런트엔드 자동 배포, PR 프리뷰, Docker 배포 파이프라인, 서버리스 헬스체크 → [`assignments/L10/README.md`](assignments/L10/README.md)
+- **[11주차]** Feature Flag, A/B 테스트, Canary Rollout 검증 → [`assignments/L11/README.md`](assignments/L11/README.md)

--- a/api/flags.js
+++ b/api/flags.js
@@ -1,0 +1,12 @@
+const { getUserId, getAllFlags } = require("../src/featureFlags");
+const { getAssignments } = require("../src/experiments");
+
+module.exports = (req, res) => {
+  const userId = getUserId(req);
+
+  res.status(200).json({
+    userId,
+    flags: getAllFlags(userId),
+    experiments: getAssignments(userId),
+  });
+};

--- a/api/health.js
+++ b/api/health.js
@@ -1,7 +1,17 @@
 module.exports = (req, res) => {
+  if (process.env.SIMULATE_HEALTH_FAIL === "true") {
+    res.status(500).json({
+      status: "unhealthy",
+      service: "aioss-week11",
+      platform: "vercel-serverless",
+      reason: "SIMULATE_HEALTH_FAIL is true",
+    });
+    return;
+  }
+
   res.status(200).json({
     status: "healthy",
-    service: "aioss-week10",
-    platform: "vercel-serverless"
+    service: "aioss-week11",
+    platform: "vercel-serverless",
   });
 };

--- a/api/rollout.js
+++ b/api/rollout.js
@@ -1,0 +1,13 @@
+const { getUserId } = require("../src/featureFlags");
+const { isUserInCanary } = require("../src/canary");
+
+module.exports = (req, res) => {
+  const userId = getUserId(req);
+  const canaryPercent = Number(process.env.CANARY_PERCENT || 0);
+
+  res.status(200).json({
+    userId,
+    canaryPercent,
+    inCanary: isUserInCanary(userId, canaryPercent),
+  });
+};

--- a/api/track.js
+++ b/api/track.js
@@ -1,0 +1,60 @@
+const { getUserId } = require("../src/featureFlags");
+const { trackEvent } = require("../src/experiments");
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    if (req.body && typeof req.body === "object") {
+      resolve(req.body);
+      return;
+    }
+
+    if (req.body && typeof req.body === "string") {
+      try {
+        resolve(JSON.parse(req.body));
+      } catch {
+        resolve({});
+      }
+      return;
+    }
+
+    let data = "";
+
+    req.on("data", (chunk) => {
+      data += chunk;
+    });
+
+    req.on("end", () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+module.exports = async (req, res) => {
+  if (req.method !== "POST") {
+    res.status(405).json({
+      error: "Method Not Allowed",
+      allowed: "POST",
+    });
+    return;
+  }
+
+  const body = await readBody(req);
+  const userId = body.userId || getUserId(req);
+
+  const event = trackEvent({
+    userId,
+    eventName: body.eventName || "unknown_event",
+    experimentName: body.experimentName || "unknown_experiment",
+    variant: body.variant || "unknown_variant",
+    metadata: body.metadata || {},
+  });
+
+  res.status(200).json({
+    tracked: true,
+    event,
+  });
+};

--- a/assignments/L11/README.md
+++ b/assignments/L11/README.md
@@ -1,0 +1,84 @@
+# Week 11 과제 정리
+
+11주차 과제에서는 Feature Flag, A/B 테스트, Canary 롤아웃 검증을 한 흐름으로 정리했다. 핵심 목표는 환경 변수와 대상 사용자 기준으로 기능을 제어하고, 실험 배정은 사용자별로 일관되게 유지하며, 선택과제로 Canary 단계 롤아웃과 자동 롤백 시나리오까지 확인하는 것이다.
+
+## 구현 요약
+
+### 1) Feature Flag 3개 이상 도입
+
+다음 3개의 Feature Flag를 도입했다.
+
+- `doraDashboard`: DORA 대시보드 링크 노출
+- `betaStatusApi`: Beta Status API 카드 노출
+- `canaryBanner`: Canary 롤아웃 안내 배너 노출
+
+각 플래그는 환경 변수와 대상 사용자 목록으로 제어한다.
+
+- 전역 활성화: `FEATURE_DORA_DASHBOARD`, `FEATURE_BETA_STATUS_API`, `FEATURE_CANARY_BANNER`
+- 대상 사용자 제어: `FEATURE_DORA_USERS`, `FEATURE_BETA_USERS`, `FEATURE_CANARY_USERS`
+
+동일한 사용자에 대해 대상 사용자 목록이 우선 적용되고, 그 다음에 전역 환경 변수 값을 반영한다.
+
+### 2) A/B 테스트 2개 variant 구성
+
+`homeHeroCopy` 실험을 추가해 `A` / `B` 두 variant를 구성했다. 사용자 할당은 `experimentName:userId` 문자열을 해시하는 방식으로 계산해서, 같은 사용자는 항상 같은 variant를 받도록 했다.
+
+이벤트 추적도 함께 추가했다.
+
+- `experiment_exposure`: 실험 노출 기록
+- `cta_click`: CTA 클릭 기록
+
+추적 payload는 `userId`, `experimentName`, `variant`, `eventName`, `metadata`를 포함한다.
+
+### 3) 선택과제 Canary 롤아웃 검증
+
+`1% -> 10% -> 50% -> 100%` 단계로 Canary 롤아웃이 진행되는 시나리오를 검증했다. `health check`가 실패하면 자동으로 직전 단계로 롤백되는 흐름도 로그로 남겼다.
+
+## 검증 결과
+
+- 최소 3개 이상의 Feature Flag가 반환된다.
+- 동일한 `userId`는 항상 동일한 A/B variant를 받는다.
+- 이벤트 추적 시 `experiment_exposure`와 `cta_click`이 기록된다.
+- Canary 단계에서 `health=unhealthy`이면 `rollback`이 발생한다.
+
+## 관련 파일
+
+- Feature Flag 코드: [src/featureFlags.js](../../src/featureFlags.js)
+- A/B 테스트 및 이벤트 추적 코드: [src/experiments.js](../../src/experiments.js)
+- Canary 롤아웃 코드: [src/canary.js](../../src/canary.js)
+- 플래그 API: [api/flags.js](../../api/flags.js)
+- 실험 트래킹 API: [api/track.js](../../api/track.js)
+- Canary 상태 API: [api/rollout.js](../../api/rollout.js)
+- 실험 로그: [experiment-log.md](experiment-log.md)
+- Canary 로그: [canary-rollout-log.md](canary-rollout-log.md)
+
+## GitHub 링크
+
+- Feature Flag 코드: https://github.com/chaeyeong3199/AIOSS/blob/main/src/featureFlags.js
+- A/B 테스트 코드: https://github.com/chaeyeong3199/AIOSS/blob/main/src/experiments.js
+- Canary 롤아웃 코드: https://github.com/chaeyeong3199/AIOSS/blob/main/src/canary.js
+- 실험 로그: https://github.com/chaeyeong3199/AIOSS/blob/main/assignments/L11/experiment-log.md
+- Canary 로그: https://github.com/chaeyeong3199/AIOSS/blob/main/assignments/L11/canary-rollout-log.md
+- API 플래그 엔드포인트: https://github.com/chaeyeong3199/AIOSS/blob/main/api/flags.js
+- 트래킹 엔드포인트: https://github.com/chaeyeong3199/AIOSS/blob/main/api/track.js
+- 롤아웃 엔드포인트: https://github.com/chaeyeong3199/AIOSS/blob/main/api/rollout.js
+
+## 실행 메모
+
+환경 변수를 바꿔서 플래그를 확인할 수 있다.
+
+```bash
+FEATURE_DORA_DASHBOARD=true
+FEATURE_DORA_USERS=chaeyoung,tester
+FEATURE_BETA_STATUS_API=true
+FEATURE_BETA_USERS=guest
+FEATURE_CANARY_BANNER=false
+FEATURE_CANARY_USERS=chaeyoung
+CANARY_PERCENT=10
+```
+
+위 설정에서 `/api/flags`, `/api/track`, `/api/rollout`을 확인하면 과제 요구사항을 한 번에 검증할 수 있다.
+
+---
+
+※ 본 README 및 과제 산출물의 일부 코드/문서는 생성형 AI 도구의 도움을 받아 작성되었습니다.

--- a/assignments/L11/canary-rollout-log.md
+++ b/assignments/L11/canary-rollout-log.md
@@ -1,0 +1,10 @@
+# Canary Rollout Log
+
+```txt
+[canary] stage=1% health=healthy
+[promote] current=1% next=10% reason="health check passed"
+[canary] stage=10% health=healthy
+[promote] current=10% next=50% reason="health check passed"
+[canary] stage=50% health=unhealthy
+[rollback] failed_stage=50% rollback_to=10% reason="health check failed"
+```

--- a/assignments/L11/experiment-log.md
+++ b/assignments/L11/experiment-log.md
@@ -1,0 +1,42 @@
+# Week 11 A/B Test Experiment Log
+
+## 실험 개요
+
+- Experiment Name: `homeHeroCopy`
+- Variant A: 기존 제목 문구 사용
+- Variant B: 개선된 제목 문구 사용
+- 사용자 할당 방식: `experimentName:userId` 기반 hash
+- 일관성 검증: 동일 userId는 항상 동일 variant를 받도록 구현
+
+## 테스트 사용자
+
+| userId | Assigned Variant | Event |
+|---|---|---|
+| chaeyoung | A 또는 B | experiment_exposure |
+| guest | A 또는 B | experiment_exposure |
+| tester | A 또는 B | cta_click |
+
+## 이벤트 추적 방식
+
+프런트엔드에서 `/api/track`으로 이벤트를 전송한다.
+
+추적 이벤트 예시:
+
+```json
+{
+  "userId": "chaeyoung",
+  "eventName": "experiment_exposure",
+  "experimentName": "homeHeroCopy",
+  "variant": "A",
+  "metadata": {
+    "page": "public/index.html"
+  }
+}
+```
+
+## 검증 결과
+
+- /api/flags?userId=chaeyoung 호출 시 Feature Flag와 A/B variant가 함께 반환됨
+- 같은 userId로 반복 호출해도 동일한 variant가 반환됨
+- 페이지 진입 시 experiment_exposure 이벤트가 기록됨
+- 버튼 클릭 시 cta_click 이벤트가 기록됨

--- a/public/index.html
+++ b/public/index.html
@@ -67,6 +67,38 @@
   </div>
 
   <div class="card">
+    <h2>Week 11 Feature Flags</h2>
+    <p>Current User: <code id="currentUser">-</code></p>
+    <ul id="flagList">
+      <li>Loading flags...</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>A/B Test Assignment</h2>
+    <p>
+      Experiment:
+      <code>homeHeroCopy</code>
+    </p>
+    <p>
+      Assigned Variant:
+      <code id="abVariant">-</code>
+    </p>
+    <button id="trackClickButton">Track CTA Click Event</button>
+    <p id="trackResult"></p>
+  </div>
+
+  <div class="card" id="betaStatusCard" style="display: none;">
+    <h2>Beta Status API</h2>
+    <p id="betaStatusResult">Loading beta status...</p>
+  </div>
+
+  <div class="card" id="canaryBanner" style="display: none;">
+    <h2>Canary Rollout</h2>
+    <p>이 배너는 Canary 대상 사용자 또는 환경 변수 활성화 시에만 표시됩니다.</p>
+  </div>  
+
+  <div class="card">
     <h2>Docker Deployment Strategy</h2>
     <p>
       Docker 이미지는 GitHub Actions에서 빌드 및 검증하고,
@@ -98,8 +130,93 @@
         healthEl.innerHTML = '<span class="fail">Error</span> - Health Check 요청 실패';
       }
     }
+    async function loadWeek11Features() {
+      const params = new URLSearchParams(window.location.search);
+      const userId =
+        params.get("userId") ||
+        localStorage.getItem("aiossUserId") ||
+        "guest";
 
+      localStorage.setItem("aiossUserId", userId);
+      document.getElementById("currentUser").textContent = userId;
+
+      const response = await fetch(`/api/flags?userId=${encodeURIComponent(userId)}`);
+      const data = await response.json();
+
+      const flagList = document.getElementById("flagList");
+      flagList.innerHTML = "";
+
+      Object.entries(data.flags).forEach(([flagName, flag]) => {
+        const li = document.createElement("li");
+        li.innerHTML = `<code>${flagName}</code>: ${flag.enabled ? "ON" : "OFF"} - ${flag.description}`;
+        flagList.appendChild(li);
+      });
+
+      const heroExperiment = data.experiments.homeHeroCopy;
+      const variant = heroExperiment.variant;
+
+      document.getElementById("abVariant").textContent = variant;
+
+      if (variant === "B") {
+        document.querySelector("h1").textContent =
+          "AIOSS Week 11 Feature Flag Experiment Dashboard";
+      }
+
+      await fetch("/api/track", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          userId,
+          eventName: "experiment_exposure",
+          experimentName: "homeHeroCopy",
+          variant,
+          metadata: {
+            page: "public/index.html",
+          },
+        }),
+      });
+
+      if (data.flags.betaStatusApi.enabled) {
+        document.getElementById("betaStatusCard").style.display = "block";
+
+        const statusResponse = await fetch("/api/status");
+        const statusData = await statusResponse.json();
+
+        document.getElementById("betaStatusResult").textContent =
+          `${statusData.message} / ${statusData.status}`;
+      }
+
+      if (data.flags.canaryBanner.enabled) {
+        document.getElementById("canaryBanner").style.display = "block";
+      }
+
+      document.getElementById("trackClickButton").addEventListener("click", async () => {
+        const trackResponse = await fetch("/api/track", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            userId,
+            eventName: "cta_click",
+            experimentName: "homeHeroCopy",
+            variant,
+            metadata: {
+              button: "trackClickButton",
+            },
+          }),
+        });
+
+        const trackData = await trackResponse.json();
+
+        document.getElementById("trackResult").textContent =
+          `Tracked: ${trackData.event.eventName} / ${trackData.event.variant}`;
+      });
+    }
     checkHealth();
+    loadWeek11Features();
   </script>
 </body>
 </html>

--- a/scripts/verify-canary-rollout.js
+++ b/scripts/verify-canary-rollout.js
@@ -1,0 +1,49 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { CANARY_STAGES, decideRollout } = require("../src/canary");
+
+const failAt = Number(process.env.SIMULATE_HEALTH_FAIL_AT || 0);
+const logLines = [];
+
+let currentPercent = 0;
+
+for (const stage of CANARY_STAGES) {
+  const healthStatus = failAt && stage >= failAt ? "unhealthy" : "healthy";
+
+  logLines.push(
+    `[canary] stage=${stage}% health=${healthStatus}`
+  );
+
+  const decision = decideRollout({
+    currentPercent: stage,
+    healthStatus,
+  });
+
+  if (decision.action === "rollback") {
+    logLines.push(
+      `[rollback] failed_stage=${stage}% rollback_to=${currentPercent}% reason="${decision.reason}"`
+    );
+    break;
+  }
+
+  currentPercent = stage;
+
+  logLines.push(
+    `[promote] current=${stage}% next=${decision.nextPercent}% reason="${decision.reason}"`
+  );
+}
+
+const outputDir = path.join(process.cwd(), "assignments", "L11");
+fs.mkdirSync(outputDir, { recursive: true });
+
+const outputPath = path.join(outputDir, "canary-rollout-log.md");
+
+fs.writeFileSync(
+  outputPath,
+  ["# Canary Rollout Log", "", "```txt", ...logLines, "```", ""].join("\n"),
+  "utf8"
+);
+
+console.log(logLines.join("\n"));
+console.log(`Saved rollout log to ${outputPath}`);

--- a/src/canary.js
+++ b/src/canary.js
@@ -1,0 +1,56 @@
+const CANARY_STAGES = [1, 10, 50, 100];
+
+function hashString(input) {
+  let hash = 2166136261;
+
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+function getCanaryBucket(userId = "anonymous") {
+  return hashString(`canary:${userId}`) % 100;
+}
+
+function isUserInCanary(userId, percent) {
+  const safePercent = Math.max(0, Math.min(100, Number(percent) || 0));
+
+  return getCanaryBucket(userId) < safePercent;
+}
+
+function getNextCanaryStage(currentPercent) {
+  const currentIndex = CANARY_STAGES.indexOf(Number(currentPercent));
+
+  if (currentIndex === -1) {
+    return CANARY_STAGES[0];
+  }
+
+  return CANARY_STAGES[Math.min(currentIndex + 1, CANARY_STAGES.length - 1)];
+}
+
+function decideRollout({ currentPercent, healthStatus }) {
+  if (healthStatus !== "healthy") {
+    return {
+      action: "rollback",
+      nextPercent: 0,
+      reason: "health check failed",
+    };
+  }
+
+  return {
+    action: "promote",
+    nextPercent: getNextCanaryStage(currentPercent),
+    reason: "health check passed",
+  };
+}
+
+module.exports = {
+  CANARY_STAGES,
+  getCanaryBucket,
+  isUserInCanary,
+  getNextCanaryStage,
+  decideRollout,
+};

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -1,0 +1,75 @@
+const EXPERIMENTS = {
+  homeHeroCopy: {
+    description: "메인 페이지 제목 문구 A/B 테스트",
+    variants: ["A", "B"],
+  },
+};
+
+function hashString(input) {
+  let hash = 2166136261;
+
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+function assignVariant(experimentName, userId = "anonymous") {
+  const experiment = EXPERIMENTS[experimentName];
+
+  if (!experiment) {
+    return null;
+  }
+
+  const bucket = hashString(`${experimentName}:${userId}`);
+  const index = bucket % experiment.variants.length;
+
+  return experiment.variants[index];
+}
+
+function getAssignments(userId = "anonymous") {
+  return Object.keys(EXPERIMENTS).reduce((result, experimentName) => {
+    result[experimentName] = {
+      variant: assignVariant(experimentName, userId),
+      description: EXPERIMENTS[experimentName].description,
+    };
+
+    return result;
+  }, {});
+}
+
+function createTrackingEvent({
+  userId = "anonymous",
+  eventName,
+  experimentName,
+  variant,
+  metadata = {},
+}) {
+  return {
+    timestamp: new Date().toISOString(),
+    userId,
+    eventName,
+    experimentName,
+    variant,
+    metadata,
+  };
+}
+
+function trackEvent(event) {
+  const trackingEvent = createTrackingEvent(event);
+
+  console.log("[experiment-event]", JSON.stringify(trackingEvent));
+
+  return trackingEvent;
+}
+
+module.exports = {
+  EXPERIMENTS,
+  hashString,
+  assignVariant,
+  getAssignments,
+  createTrackingEvent,
+  trackEvent,
+};

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -1,0 +1,102 @@
+const FEATURE_DEFINITIONS = {
+  doraDashboard: {
+    description: "DORA Dashboard 링크 노출 여부",
+    envKey: "FEATURE_DORA_DASHBOARD",
+    targetUsersEnvKey: "FEATURE_DORA_USERS",
+    defaultValue: false,
+  },
+  betaStatusApi: {
+    description: "Beta Status API 카드 노출 여부",
+    envKey: "FEATURE_BETA_STATUS_API",
+    targetUsersEnvKey: "FEATURE_BETA_USERS",
+    defaultValue: false,
+  },
+  canaryBanner: {
+    description: "Canary Rollout 안내 배너 노출 여부",
+    envKey: "FEATURE_CANARY_BANNER",
+    targetUsersEnvKey: "FEATURE_CANARY_USERS",
+    defaultValue: false,
+  },
+};
+
+function parseBoolean(value, defaultValue = false) {
+  if (value == null || value === "") return defaultValue;
+
+  const normalized = String(value).trim().toLowerCase();
+
+  if (["true", "1", "yes", "on", "enabled"].includes(normalized)) {
+    return true;
+  }
+
+  if (["false", "0", "no", "off", "disabled"].includes(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+}
+
+function parseTargetUsers(value) {
+  if (!value) return [];
+
+  return String(value)
+    .split(",")
+    .map((user) => user.trim())
+    .filter(Boolean);
+}
+
+function getUserId(req) {
+  const headerUser =
+    req?.headers?.["x-user-id"] ||
+    req?.headers?.["X-User-Id"] ||
+    req?.headers?.["x-user"];
+
+  if (headerUser) return String(headerUser);
+
+  if (req?.query?.userId) {
+    return String(req.query.userId);
+  }
+
+  if (req?.url) {
+    const url = new URL(req.url, "http://localhost");
+    const userId = url.searchParams.get("userId");
+    if (userId) return userId;
+  }
+
+  return "anonymous";
+}
+
+function isFeatureEnabled(flagName, userId = "anonymous", env = process.env) {
+  const flag = FEATURE_DEFINITIONS[flagName];
+
+  if (!flag) {
+    return false;
+  }
+
+  const targetUsers = parseTargetUsers(env[flag.targetUsersEnvKey]);
+
+  if (targetUsers.includes(userId)) {
+    return true;
+  }
+
+  return parseBoolean(env[flag.envKey], flag.defaultValue);
+}
+
+function getAllFlags(userId = "anonymous", env = process.env) {
+  return Object.keys(FEATURE_DEFINITIONS).reduce((result, flagName) => {
+    result[flagName] = {
+      enabled: isFeatureEnabled(flagName, userId, env),
+      description: FEATURE_DEFINITIONS[flagName].description,
+    };
+
+    return result;
+  }, {});
+}
+
+module.exports = {
+  FEATURE_DEFINITIONS,
+  parseBoolean,
+  parseTargetUsers,
+  getUserId,
+  isFeatureEnabled,
+  getAllFlags,
+};

--- a/src/server.js
+++ b/src/server.js
@@ -1,18 +1,62 @@
 const express = require("express");
+const path = require("path");
 const { hello } = require("./index");
+const { getAllFlags, getUserId } = require("./featureFlags");
+const { getAssignments, trackEvent } = require("./experiments");
 
 const app = express();
 const port = process.env.PORT || 3000;
 
-app.get("/", (req, res) => {
-  res.json({
-    message: hello("AIOSS Week 9"),
-    status: "ok"
-  });
-});
+app.use(express.json());
+
+// public 폴더를 정적 파일로 제공
+app.use(express.static(path.join(__dirname, "..", "public")));
 
 app.get("/health", (req, res) => {
   res.json({ status: "healthy" });
+});
+
+app.get("/api/health", (req, res) => {
+  res.json({
+    status: "healthy",
+    service: "aioss-week11",
+    platform: "express-local",
+  });
+});
+
+app.get("/api/status", (req, res) => {
+  res.json({
+    message: hello("AIOSS Week 11"),
+    status: "ok",
+    deployment: "express-local",
+  });
+});
+
+app.get("/api/flags", (req, res) => {
+  const userId = getUserId(req);
+
+  res.json({
+    userId,
+    flags: getAllFlags(userId),
+    experiments: getAssignments(userId),
+  });
+});
+
+app.post("/api/track", (req, res) => {
+  const userId = req.body.userId || getUserId(req);
+
+  const event = trackEvent({
+    userId,
+    eventName: req.body.eventName,
+    experimentName: req.body.experimentName,
+    variant: req.body.variant,
+    metadata: req.body.metadata,
+  });
+
+  res.json({
+    tracked: true,
+    event,
+  });
 });
 
 app.listen(port, () => {

--- a/tests/l11-feature-flags.test.js
+++ b/tests/l11-feature-flags.test.js
@@ -1,0 +1,79 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const {
+  isFeatureEnabled,
+  getAllFlags,
+} = require("../src/featureFlags");
+
+const {
+  assignVariant,
+  getAssignments,
+  trackEvent,
+} = require("../src/experiments");
+
+test("environment variable can enable feature flag", () => {
+  const env = {
+    FEATURE_DORA_DASHBOARD: "true",
+  };
+
+  assert.strictEqual(
+    isFeatureEnabled("doraDashboard", "guest", env),
+    true
+  );
+});
+
+test("target user can enable feature flag even when global env is false", () => {
+  const env = {
+    FEATURE_DORA_DASHBOARD: "false",
+    FEATURE_DORA_USERS: "chaeyoung,tester",
+  };
+
+  assert.strictEqual(
+    isFeatureEnabled("doraDashboard", "chaeyoung", env),
+    true
+  );
+
+  assert.strictEqual(
+    isFeatureEnabled("doraDashboard", "guest", env),
+    false
+  );
+});
+
+test("at least three feature flags are returned", () => {
+  const flags = getAllFlags("guest", {});
+
+  assert.ok(Object.keys(flags).length >= 3);
+  assert.ok(flags.doraDashboard);
+  assert.ok(flags.betaStatusApi);
+  assert.ok(flags.canaryBanner);
+});
+
+test("same user gets consistent A/B variant", () => {
+  const first = assignVariant("homeHeroCopy", "chaeyoung");
+  const second = assignVariant("homeHeroCopy", "chaeyoung");
+
+  assert.strictEqual(first, second);
+});
+
+test("A/B assignment returns one of two variants", () => {
+  const assignments = getAssignments("chaeyoung");
+  const variant = assignments.homeHeroCopy.variant;
+
+  assert.ok(["A", "B"].includes(variant));
+});
+
+test("tracking event includes user, experiment, variant and event name", () => {
+  const event = trackEvent({
+    userId: "chaeyoung",
+    eventName: "experiment_exposure",
+    experimentName: "homeHeroCopy",
+    variant: "A",
+  });
+
+  assert.strictEqual(event.userId, "chaeyoung");
+  assert.strictEqual(event.eventName, "experiment_exposure");
+  assert.strictEqual(event.experimentName, "homeHeroCopy");
+  assert.strictEqual(event.variant, "A");
+  assert.ok(event.timestamp);
+});


### PR DESCRIPTION
## Summary
- Added 3 feature flags controlled by environment variables and target users
- Added deterministic A/B test assignment logic
- Added experiment exposure and click event tracking
- Added optional canary rollout and rollback verification scenario

## Test
- npm test
- /api/flags?userId=guest
- /api/flags?userId=chaeyoung
- node scripts/verify-canary-rollout.js